### PR TITLE
Only one target for the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,24 +7,13 @@ endif()
 project(cobs VERSION 1.0 LANGUAGES C CXX)
 include(GNUInstallDirs)
 
-add_library(cobs SHARED cobs.h cobs.c)
+add_library(cobs cobs.h cobs.c)
 set_target_properties(cobs PROPERTIES
   SOVERSION 1
   VERSION ${PROJECT_VERSION}
   PUBLIC_HEADER cobs.h
 )
 install(TARGETS cobs
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-add_library(cobs_static STATIC cobs.h cobs.c)
-set_target_properties(cobs_static PROPERTIES
-  VERSION ${PROJECT_VERSION}
-  PUBLIC_HEADER cobs.h
-)
-install(TARGETS cobs_static
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
building static/dynamic libs should be configured with cmake's BUILD_SHARED_LIBS flag. https://cmake.org/cmake/help/v3.0/variable/BUILD_SHARED_LIBS.html

This allows better integration with conan and we can just build packages with `shared=True` or `shared=False` settings. https://docs.conan.io/en/latest/howtos/manage_shared_libraries/env_vars.html